### PR TITLE
CreateWorkAwards: add DataCite Awards source (oxjob #125.1)

### DIFF
--- a/jobs/create_work_awards.json
+++ b/jobs/create_work_awards.json
@@ -97,6 +97,34 @@
         },
         {
           "email_notifications": {},
+          "pipeline_task": {
+            "full_refresh": false,
+            "pipeline_id": "REPLACE_WITH_DATACITE_AWARDS_PIPELINE_ID"
+          },
+          "run_if": "ALL_SUCCESS",
+          "task_key": "DataCite_Awards",
+          "timeout_seconds": 0,
+          "webhook_notifications": {}
+        },
+        {
+          "depends_on": [
+            {
+              "task_key": "DataCite_Awards"
+            }
+          ],
+          "email_notifications": {},
+          "environment_key": "Default",
+          "notebook_task": {
+            "notebook_path": "notebooks/awards/InsertDataCiteAwardsToRaw",
+            "source": "GIT"
+          },
+          "run_if": "ALL_SUCCESS",
+          "task_key": "DataCite_Awards_Insert",
+          "timeout_seconds": 0,
+          "webhook_notifications": {}
+        },
+        {
+          "email_notifications": {},
           "environment_key": "Default",
           "notebook_task": {
             "notebook_path": "/Workspace/Shared/openalex-walden/notebooks/awards/CreateFormasAwards",
@@ -339,6 +367,9 @@
             },
             {
               "task_key": "Crossref_Awards_Insert"
+            },
+            {
+              "task_key": "DataCite_Awards_Insert"
             },
             {
               "task_key": "NWO_Awards"

--- a/notebooks/awards/CreateDataCiteAwards.ipynb
+++ b/notebooks/awards/CreateDataCiteAwards.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "9a17b2c4-5e1f-4f62-9d2c-1f0a5e3d7a01",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "### Create awards from DataCite records where resourceTypeGeneral is \"Award\"\n\nMirrors `CreateCrossrefAwards` for DataCite. Strict filter: only records with `attributes.types.resourceTypeGeneral == 'Award'`. ESRF (`10.15151/`) records are out of scope here \u2014 they are `resourceTypeGeneral == 'Dataset'` and are handled by the work\u2194funder/award linkage job (#125.2)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "f1d4a3c8-2b9e-4a55-8b73-7d9c2e6f3b02",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": "import dlt\nimport pyspark.sql.functions as F\nfrom pyspark.sql.window import Window\n\n\nINVESTIGATOR_STRUCT = (\n    \"struct<\"\n    \"given_name:string,\"\n    \"family_name:string,\"\n    \"orcid:string,\"\n    \"role_start:date,\"\n    \"affiliation:struct<\"\n    \"name:string,\"\n    \"country:string,\"\n    \"ids:array<struct<id:string,type:string,asserted_by:string>>\"\n    \">\"\n    \">\"\n)\n\n\ndef parse_datacite_person(person_col):\n    \"\"\"\n    Parse a DataCite creator/contributor entry (nameType='Personal') into the\n    OpenAlex investigator schema. Mirrors the shape produced by parse_investigator\n    in CreateCrossrefAwards but sourced from DataCite fields.\n    \"\"\"\n    return F.struct(\n        person_col[\"givenName\"].alias(\"given_name\"),\n        person_col[\"familyName\"].alias(\"family_name\"),\n        F.when(\n            F.get(person_col[\"nameIdentifiers\"][\"nameIdentifierScheme\"], 0) == \"ORCID\",\n            F.regexp_extract(\n                F.get(person_col[\"nameIdentifiers\"], 0)[\"nameIdentifier\"],\n                r\"(\\d{4}-\\d{4}-\\d{4}-\\d{3}[\\dXx])\",\n                1,\n            ),\n        ).alias(\"orcid\"),\n        # DataCite has no role-start equivalent\n        F.lit(None).cast(\"date\").alias(\"role_start\"),\n        F.when(\n            F.size(person_col[\"affiliation\"]) > 0,\n            F.struct(\n                person_col[\"affiliation\"][0][\"name\"].alias(\"name\"),\n                F.lit(None).cast(\"string\").alias(\"country\"),\n                F.when(\n                    F.lower(person_col[\"affiliation\"][0][\"affiliationIdentifierScheme\"]) == \"ror\",\n                    F.array(\n                        F.struct(\n                            person_col[\"affiliation\"][0][\"affiliationIdentifier\"].alias(\"id\"),\n                            F.lit(\"ROR\").alias(\"type\"),\n                            F.lit(None).cast(\"string\").alias(\"asserted_by\"),\n                        )\n                    ),\n                )\n                .otherwise(\n                    F.array().cast(\"array<struct<id:string,type:string,asserted_by:string>>\")\n                )\n                .alias(\"ids\"),\n            ),\n        ).alias(\"affiliation\"),\n    )\n\n\n@dlt.table(name=\"datacite_award_items\")\ndef datacite_award_items():\n    return (\n        spark.read.table(\"openalex.datacite.datacite_items\")\n        .filter(F.col(\"attributes.types.resourceTypeGeneral\") == \"Award\")\n    )\n\n\n@dlt.table(name=\"datacite_award_items_deduplicated\")\ndef datacite_award_items_deduplicated():\n    df = dlt.read(\"datacite_award_items\")\n    window = Window.partitionBy(\"id\").orderBy(F.col(\"attributes.updated\").desc())\n    return (\n        df\n        .withColumn(\"row_num\", F.row_number().over(window))\n        .filter(F.col(\"row_num\") == 1)\n        .drop(\"row_num\")\n    )\n\n\n@dlt.table(name=\"datacite_awards\")\ndef datacite_awards():\n    df = dlt.read(\"datacite_award_items_deduplicated\")\n    df_funders = spark.read.table(\"openalex.common.funder\")\n\n    fund_ref_0 = F.col(\"attributes.fundingReferences\").getItem(0)\n\n    # Investigator candidates, in priority order (PLAN.md):\n    # 1. contributors with research roles (Personal)\n    # 2. contributors with Researcher (Personal)\n    # 3. creators (Personal)\n    contributors_pi = F.filter(\n        F.col(\"attributes.contributors\"),\n        lambda c: (c[\"nameType\"] == \"Personal\")\n        & c[\"contributorType\"].isin(\n            \"ProjectLeader\", \"ProjectManager\", \"PrincipalInvestigator\"\n        ),\n    )\n    contributors_researcher = F.filter(\n        F.col(\"attributes.contributors\"),\n        lambda c: (c[\"nameType\"] == \"Personal\") & (c[\"contributorType\"] == \"Researcher\"),\n    )\n    creators_personal = F.filter(\n        F.col(\"attributes.creators\"),\n        lambda c: c[\"nameType\"] == \"Personal\",\n    )\n\n    lead_candidate = F.coalesce(\n        F.get(contributors_pi, 0),\n        F.get(contributors_researcher, 0),\n        F.get(creators_personal, 0),\n    )\n\n    # Investigators array: union of Personal creators + research-role Personal contributors.\n    # No dedup in v1 \u2014 documented limitation; downstream consumers can dedup if needed.\n    contributors_research_all = F.filter(\n        F.col(\"attributes.contributors\"),\n        lambda c: (c[\"nameType\"] == \"Personal\")\n        & c[\"contributorType\"].isin(\n            \"ProjectLeader\", \"ProjectManager\", \"PrincipalInvestigator\", \"Researcher\"\n        ),\n    )\n    all_investigators_raw = F.concat(creators_personal, contributors_research_all)\n\n    # Description: first Abstract or Other.\n    description_value = F.get(\n        F.filter(\n            F.col(\"attributes.descriptions\"),\n            lambda d: d[\"descriptionType\"].isin(\"Abstract\", \"Other\"),\n        ),\n        0,\n    )[\"description\"]\n\n    # Date helpers. DataCite supports range syntax \"2020-01-01/2024-12-31\".\n    def first_date_of_type(date_type):\n        return F.to_date(\n            F.split(\n                F.get(\n                    F.filter(\n                        F.col(\"attributes.dates\"),\n                        lambda d: d[\"dateType\"] == date_type,\n                    ),\n                    0,\n                )[\"date\"],\n                \"/\",\n            ).getItem(0)\n        )\n\n    valid_range_split = F.split(\n        F.get(\n            F.filter(\n                F.col(\"attributes.dates\"),\n                lambda d: d[\"dateType\"] == \"Valid\",\n            ),\n            0,\n        )[\"date\"],\n        \"/\",\n    )\n    end_date_value = F.when(F.size(valid_range_split) >= 2, F.to_date(valid_range_split.getItem(1)))\n\n    # Funder identifier extraction from fundingReferences[0]\n    join_ror_id = F.when(\n        fund_ref_0[\"funderIdentifierType\"] == \"ROR\", fund_ref_0[\"funderIdentifier\"]\n    )\n    join_doi = F.when(\n        fund_ref_0[\"funderIdentifierType\"].isin(\"DOI\", \"Crossref Funder ID\"),\n        F.regexp_replace(fund_ref_0[\"funderIdentifier\"], r\"^https?://(dx\\.)?doi\\.org/\", \"\"),\n    )\n\n    # Stage everything we need for the join + projection\n    df_staged = df.select(\n        \"*\",\n        fund_ref_0.alias(\"fund_ref\"),\n        F.coalesce(\n            fund_ref_0[\"awardNumber\"],\n            F.regexp_extract(F.col(\"id\"), r\"10\\.\\d+/(.+)\", 1),\n        ).alias(\"funder_award_id\"),\n        F.lower(F.col(\"attributes.publisher\")).alias(\"publisher_lower\"),\n        join_ror_id.alias(\"join_ror_id\"),\n        join_doi.alias(\"join_doi\"),\n        lead_candidate.alias(\"lead_candidate\"),\n        all_investigators_raw.alias(\"all_investigators_raw\"),\n        description_value.alias(\"description\"),\n        F.coalesce(\n            first_date_of_type(\"Issued\"),\n            first_date_of_type(\"Created\"),\n            F.to_date(F.col(\"attributes.created\")),\n        ).alias(\"start_date\"),\n        end_date_value.alias(\"end_date\"),\n    )\n\n    df_funders_ready = df_funders.select(\n        F.col(\"funder_id\").alias(\"f_funder_id\"),\n        F.col(\"display_name\").alias(\"f_display_name\"),\n        F.col(\"ror_id\").alias(\"f_ror_id\"),\n        F.col(\"doi\").alias(\"f_doi\"),\n        F.lower(F.col(\"display_name\")).alias(\"f_display_name_lower\"),\n    )\n\n    # ID hash key: prefer resolved funder_id, fall back to publisher name\n    id_hash = (\n        F.abs(\n            F.xxhash64(\n                F.concat(\n                    F.coalesce(F.col(\"f_funder_id\").cast(\"string\"), F.col(\"publisher_lower\")),\n                    F.lit(\":\"),\n                    F.lower(F.col(\"funder_award_id\")),\n                )\n            )\n        )\n        % 9000000000\n    )\n\n    return (\n        df_staged.join(\n            F.broadcast(df_funders_ready),\n            (\n                ((F.col(\"join_doi\").isNotNull()) & (F.col(\"join_doi\") == F.col(\"f_doi\")))\n                | ((F.col(\"join_ror_id\").isNotNull()) & (F.col(\"join_ror_id\") == F.col(\"f_ror_id\")))\n                | (\n                    F.col(\"join_doi\").isNull()\n                    & F.col(\"join_ror_id\").isNull()\n                    & (F.col(\"publisher_lower\") == F.col(\"f_display_name_lower\"))\n                )\n            ),\n            \"left\",\n        ).select(\n            id_hash.alias(\"id\"),\n            F.col(\"attributes.titles\").getItem(0)[\"title\"].alias(\"display_name\"),\n            F.col(\"description\"),\n            F.col(\"f_funder_id\").alias(\"funder_id\"),\n            F.col(\"funder_award_id\"),\n            F.lit(None).cast(\"double\").alias(\"amount\"),\n            F.lit(None).cast(\"string\").alias(\"currency\"),\n            F.struct(\n                F.when(\n                    F.col(\"f_funder_id\").isNotNull(),\n                    F.concat(F.lit(\"https://openalex.org/F\"), F.col(\"f_funder_id\")),\n                ).alias(\"id\"),\n                F.coalesce(\n                    F.col(\"f_display_name\"),\n                    F.col(\"fund_ref.funderName\"),\n                    F.col(\"attributes.publisher\"),\n                ).alias(\"display_name\"),\n                F.col(\"f_ror_id\").alias(\"ror_id\"),\n                F.col(\"f_doi\").alias(\"doi\"),\n            ).alias(\"funder\"),\n            F.lit(None).cast(\"string\").alias(\"funding_type\"),\n            F.lit(None).cast(\"string\").alias(\"funder_scheme\"),\n            F.lit(\"datacite\").alias(\"provenance\"),\n            F.col(\"start_date\"),\n            F.col(\"end_date\"),\n            F.year(F.col(\"start_date\")).alias(\"start_year\"),\n            F.year(F.col(\"end_date\")).alias(\"end_year\"),\n            F.when(\n                F.col(\"lead_candidate\").isNotNull(),\n                parse_datacite_person(F.col(\"lead_candidate\")),\n            ).alias(\"lead_investigator\"),\n            F.lit(None).cast(INVESTIGATOR_STRUCT).alias(\"co_lead_investigator\"),\n            F.transform(F.col(\"all_investigators_raw\"), parse_datacite_person).alias(\"investigators\"),\n            F.col(\"attributes.url\").alias(\"landing_page_url\"),\n            F.concat(F.lit(\"https://doi.org/\"), F.lower(F.col(\"id\"))).alias(\"doi\"),\n            F.concat(\n                F.lit(\"https://api.openalex.org/works?filter=awards.id:G\"),\n                id_hash.cast(\"string\"),\n            ).alias(\"works_api_url\"),\n            F.to_timestamp(F.col(\"attributes.created\")).alias(\"created_date\"),\n            F.to_timestamp(F.col(\"attributes.updated\")).alias(\"updated_date\"),\n        )\n    )\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "0b5e7a36-3c84-4d18-9a72-8e2c1d6b4f03",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## Insert into openalex_awards_raw\n\nThe SQL insert lives in `InsertDataCiteAwardsToRaw.ipynb` and runs as a separate task downstream of this DLT pipeline (mirrors the Crossref pattern: `CreateCrossrefAwards` \u2192 `InsertCrossrefAwardsToRaw`)."
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "4"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "CreateDataCiteAwards",
+   "widgets": {}
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/awards/InsertDataCiteAwardsToRaw.ipynb
+++ b/notebooks/awards/InsertDataCiteAwardsToRaw.ipynb
@@ -1,0 +1,58 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "a3f0e51d-4c7b-4d12-9c5a-2d6e8f0a4b01",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "### Insert DataCite awards (provenance='datacite', priority=1) into openalex_awards_raw\n\nReads from `openalex.awards.datacite_awards` (materialized by the CreateDataCiteAwards DLT pipeline) and refreshes the `provenance='datacite' AND priority=1` slice of `openalex.awards.openalex_awards_raw`.\n\nRun downstream of the CreateDataCiteAwards DLT pipeline (DataCite_Awards task in CreateWorkAwards job).\n\nMirrors `InsertCrossrefAwardsToRaw`. Coexists with the Crossref insert because the per-source DELETE is keyed on both `provenance` and `priority`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "b7c91d28-9e6f-4a01-8b53-7a4e3c5d9e02",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": "%sql\n-- Remove previous data for this source before inserting fresh data\nDELETE FROM openalex.awards.openalex_awards_raw\nWHERE provenance = 'datacite' AND priority = 1;\n\n-- Insert into openalex_awards_raw with priority (run after DLT pipeline completes)\nINSERT INTO openalex.awards.openalex_awards_raw\nSELECT\n    id,\n    display_name,\n    description,\n    funder_id,\n    funder_award_id,\n    amount,\n    currency,\n    funder,\n    funding_type,\n    funder_scheme,\n    provenance,\n    start_date,\n    end_date,\n    start_year,\n    end_year,\n    lead_investigator,\n    co_lead_investigator,\n    investigators,\n    landing_page_url,\n    doi,\n    works_api_url,\n    created_date,\n    updated_date,\n    1 as priority\nFROM openalex.awards.datacite_awards\nWHERE openalex.common.is_usable_award_id(funder_award_id);"
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "4"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "InsertDataCiteAwardsToRaw",
+   "widgets": {}
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Mirrors the Crossref Awards pattern for DataCite records where attributes.types.resourceTypeGeneral == 'Award'.

- notebooks/awards/CreateDataCiteAwards.ipynb: DLT pipeline. Three tables (filter, dedupe by id ordered by attributes.updated, project to awards schema). Two-step funder lookup (fundingReferences ROR/DOI then publisher name match against openalex.common.funder). Investigator priority order: contributors[ProjectLeader/ProjectManager/PrincipalInvestigator] → contributors[Researcher] → creators (all Personal nameType). funder_award_id falls back to DOI suffix when fundingReferences is empty. amount/currency/funding_type/funder_scheme are always null (DataCite has no fields).

- notebooks/awards/InsertDataCiteAwardsToRaw.ipynb: DELETE + INSERT into openalex.awards.openalex_awards_raw with provenance='datacite' and priority=1. Coexists with Crossref because the per-source DELETE is keyed on both provenance AND priority. Gated by openalex.common.is_usable_award_id (verify against DOI-suffix-style IDs like '2b6r-gx60'; drop the gate for DataCite if it rejects them).

- jobs/create_work_awards.json: add DataCite_Awards (DLT pipeline_task) and DataCite_Awards_Insert (notebook_task, depends on DataCite_Awards). DataCite_Awards_Insert added to Create_Awards.depends_on.

Pipeline_id is a placeholder (REPLACE_WITH_DATACITE_AWARDS_PIPELINE_ID) — the DataCite Awards DLT pipeline must be created in Databricks UI first. That deploy is blocked on Casey (owner of openalex.awards) per the oxjob handoff brief.

Filter scope is strict (Model A only). ESRF (10.15151/) records are out of scope here; they are resourceTypeGeneral='Dataset' and will be handled by the DataCite work↔funder/award linkages job (oxjob #125.2).