### PR TITLE
Audit polish: EPA astype("string") + TWAS --output NoneType guard

### DIFF
--- a/scripts/local/epa_to_s3.py
+++ b/scripts/local/epa_to_s3.py
@@ -591,6 +591,14 @@ def save_to_parquet(df: pd.DataFrame, output_dir: Path) -> Path:
     """
     output_path = output_dir / "epa_awards.parquet"
 
+    # Runbook §1.2.5: force string dtype before to_parquet so pyarrow doesn't
+    # int-infer null-heavy columns. The upstream `pd.read_csv(..., dtype=str)`
+    # at line 481 already prevents this on the CSV read path, but the
+    # canonical pattern is the trailing astype("string") right before write —
+    # which makes the safety property obvious to readers of the write site
+    # and survives refactors of the read path.
+    df = df.astype("string")
+
     print(f"\n  [SAVE] Writing to {output_path.name}...")
     df.to_parquet(output_path, index=False)
 

--- a/scripts/local/twas_awards_to_s3.py
+++ b/scripts/local/twas_awards_to_s3.py
@@ -1078,7 +1078,11 @@ def main() -> None:
     if args.skip_upload:
         log("Skipping S3 upload because --skip-upload was set")
     else:
-        if not check_no_shrink(len(df), args.allow_shrink, Path(args.output_dir)):
+        # When invoked with only --output (no --output-dir), args.output_dir is
+        # None and Path(None) raises TypeError. Derive the output directory
+        # from args.output so the shrink-check works either way.
+        output_dir = args.output_dir if args.output_dir is not None else Path(args.output).parent
+        if not check_no_shrink(len(df), args.allow_shrink, Path(output_dir)):
             raise SystemExit("§1.4 shrink-check failed. See above; re-run with --allow-shrink if intentional.")
         upload_to_s3(args.output)
 


### PR DESCRIPTION
## Summary

Two PASS-with-notes items from the 2026-05-22 funder-PR audit. Independent of each other; combined into one tiny PR for review economy.

### EPA — runbook §1.2.5 trailing astype("string")

`scripts/local/epa_to_s3.py` reads CSVs with `dtype=str` at line 481, which already prevents the pyarrow int-inference bug the runbook warns about. The canonical pattern is still the trailing `df.astype("string")` right before `to_parquet` because:

- It puts the safety property at the **write site**, where a reader auditing parquet output can see it without tracing back to the CSV-read code.
- It survives refactors of the read path. If a future change adds a column from a different source (an API call, a join, a derived column), the upstream `dtype=str` only covers the CSV side; the trailing `astype` catches the new column too.

### TWAS — Path(args.output_dir) NoneType guard

`scripts/local/twas_awards_to_s3.py` `main()`, the shrink-check call site. The fleet-fix 2026-05-22 added `--output-dir` as an alias for the legacy `--output`. The script resolves `output_dir` to `output` correctly, but the post-write shrink-check still passed `Path(args.output_dir)` unconditionally. If a caller uses only `--output` (the legacy path), `args.output_dir` is `None` and `Path(None)` raises:

```
TypeError: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'NoneType'
```

…right before the upload step. Practical impact: the script would write the parquet correctly, then crash on the very next call when about to upload — leaving the user with a local parquet but no S3 object, and no clear error message about which flag was missing.

Fix: derive `output_dir` from `args.output`'s parent when `--output-dir` isn't passed. Either flag works for the shrink-check now.

## Test plan

- [x] `python3 -m py_compile scripts/local/epa_to_s3.py` clean.
- [x] `python3 -m py_compile scripts/local/twas_awards_to_s3.py` clean.
- [x] EPA fix is a defensive trailing `astype` — no behavior change unless a future refactor introduces a non-string column.
- [x] TWAS fix preserves existing behavior when `--output-dir` is passed; only changes behavior when `--output` alone is used (now produces a working shrink-check + upload instead of a `TypeError`).
- [ ] Optional: re-run TWAS smoke with `--output /tmp/twas_awards.parquet` (no `--output-dir`) and confirm the shrink-check no longer crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)