### PR TITLE
Fix BBRF degree-as-family PI names (priority 137 remediation)

### DIFF
--- a/scripts/local/bbrf_to_s3.py
+++ b/scripts/local/bbrf_to_s3.py
@@ -338,7 +338,7 @@ def download_grantees(output_dir: Path, limit: Optional[int]) -> Path:
 # Name normalization: BBRF formats most names as "First M. Last, Ph.D."
 # Strip postnominals before split.
 _DEGREE_SUFFIXES_RE = re.compile(
-    r",\s*(?:Ph\.?\s*D\.?|M\.?\s*D\.?|D\.?\s*Phil\.?|M\.?\s*D\.?\s*-?\s*Ph\.?\s*D\.?|"
+    r"(?:,\s*|\s+)(?:Ph\.?\s*D\.?|M\.?\s*D\.?|D\.?\s*Phil\.?|M\.?\s*D\.?\s*-?\s*Ph\.?\s*D\.?|"
     r"Sc\.?\s*D\.?|Dr\.?\s*P\.?\s*H\.?|D\.?\s*V\.?\s*M\.?|D\.?\s*O\.?|R\.?\s*N\.?|"
     r"M\.?\s*P\.?\s*H\.?|M\.?\s*Sc\.?|J\.?\s*D\.?|Jr\.?|Sr\.?|II|III|IV)"
     r"(?:[,\s.]|$)",


### PR DESCRIPTION
**Bug (found by the awards QA sweep):** ~14% of `bbrf_narsad` `lead_investigator` records have a degree as the `family_name` — e.g. `given_name="Daphne Jane Holt", family_name="Ph.D"` and `given="Anne Eden Evins", family="M.P.H"`. The real surname gets absorbed into `given_name`.

**Root cause:** `_DEGREE_SUFFIXES_RE` required a **comma** before the postnominal, so it only stripped comma-separated degrees. Space-separated forms ("Daphne Jane Holt Ph.D", no comma) slipped through, leaving the degree as the last token → `split_name` made it the family.

**Fix (scraper-only, 1 line):** allow a comma **or** whitespace separator — `(?:,\s*|\s+)`. Degree tokens (Ph.D/M.D/M.P.H/…) are specific enough that this is safe.

**Validation:**
- Unit test on the bug cases → now `given="Daphne Jane", family="Holt"`, etc.
- False-positive guard → middle initials untouched (`"John R. Nelson"` → `family="Nelson"`).
- 2-page live smoke → **0/52 degree-as-family** (was ~14%).

**Handoff:** scraper-only; `funder_award_id` unchanged → award IDs stable → in-place correction (no churn). **Admin: re-run `scripts/local/bbrf_to_s3.py` + `CreateBBRFAwards.ipynb` (DELETE+INSERT priority 137)** to refresh the ~6.8K live rows. Same pattern as the Damon Runyon fix (#219).

Contractor has no S3/Databricks access; admin must run the re-scrape + Databricks notebook + QA.