### PR TITLE
Update column mapping for grant identifier in Wellcome data

### DIFF
--- a/scripts/local/wellcome_to_s3.py
+++ b/scripts/local/wellcome_to_s3.py
@@ -187,9 +187,11 @@ def process_xlsx(xlsx_path: Path, output_dir: Path) -> Path:
     # - Grant Programme:Title
     # - Beneficiary Location:Name, Beneficiary Location:Country Code
 
+    # Note that Identifier gives the 360Giving ID so use Internal ID (Wellcome's grant reference) as the grant id
+
     # Rename 360Giving columns to our internal names
     column_mapping = {
-        'identifier': 'grant_id',
+        'internal_id': 'grant_id',
         'title': 'title',
         'description': 'description',
         'currency': 'currency',


### PR DESCRIPTION
We realised that OpenAlex is ingesting the 360Giving identifier rather than Wellcome's own. I *think* this change would fix it but obviously haven't tested it.

Internal ID holds the grant reference used by Wellcome rather than the ref provided to 360Giving.

We appreciate that this is a bit confusing and will try to update the guidance on the site in future.